### PR TITLE
Camel-case label config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,23 @@ From your repo's `Issues > Labels` section, add three labels representing the ma
 - "Version: Minor"
 - "Version: Patch"
 
-Add your label definitions to either `package.json` or to a `gsv.json` file in the base directory of your project.
+Add your label definitions to a `gsv` section of `package.json`, to a `gsv.json` file, or a `.gsvrc` file in the base directory of your project.
 
 ##### package.json example
 ```json
 "gsv": {
-  "major-label": "Version: Major",
-  "minor-label": "Version: Minor",
-  "patch-label": "Version: Patch"
+  "majorLabel": "Version: Major",
+  "minorLabel": "Version: Minor",
+  "patchLabel": "Version: Patch"
 }
 ```
 
-##### gsv.json example
+##### gsv.json or .gsvrc example
 ```json
 {
-  "major-label": "Version: Major",
-  "minor-label": "Version: Minor",
-  "patch-label": "Version: Patch"
+  "majorLabel": "Version: Major",
+  "minorLabel": "Version: Minor",
+  "patchLabel": "Version: Patch"
 }
 ```
 
@@ -179,7 +179,7 @@ calculate the package version of a repo. Ex:
   ...
   "gsv": {
     "startVersion": "2.5.0",
-    "major-label": "Version: Major",
+    "majorLabel": "Version: Major",
     ...
   },
   ...

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   ],
   "gsv": {
     "startVersion": "2.0.0",
-    "major-label": "Version: Major",
-    "minor-label": "Version: Minor",
-    "patch-label": "Version: Patch"
+    "majorLabel": "Version: Major",
+    "minorLabel": "Version: Minor",
+    "patchLabel": "Version: Patch"
   },
   "scripts": {
     "predist": "rimraf dist",

--- a/src/Version.js
+++ b/src/Version.js
@@ -25,9 +25,9 @@ export default class Version {
     };
 
     this.incrementMap = {
-      [this.config["majorLabel"]]: Version.INCREMENT_MAJOR,
-      [this.config["minorLabel"]]: Version.INCREMENT_MINOR,
-      [this.config["patchLabel"]]: Version.INCREMENT_PATCH,
+      [this.config.majorLabel]: Version.INCREMENT_MAJOR,
+      [this.config.minorLabel]: Version.INCREMENT_MINOR,
+      [this.config.patchLabel]: Version.INCREMENT_PATCH,
     };
 
     const branch = Utils.getBranch();
@@ -269,7 +269,7 @@ export default class Version {
   }
 
   getIncrementFromIssueLabels(issue) {
-    const regex = new RegExp(`^${this.config["majorLabel"]}|^${this.config["minorLabel"]}|^${this.config["patchLabel"]}`);
+    const regex = new RegExp(`^${this.config.majorLabel}|^${this.config.minorLabel}|^${this.config.patchLabel}`);
     // commits won't have labels property
     return issue.labels ? issue.labels
       .map((label) => label.name)

--- a/src/Version.js
+++ b/src/Version.js
@@ -25,9 +25,9 @@ export default class Version {
     };
 
     this.incrementMap = {
-      [this.config["major-label"]]: Version.INCREMENT_MAJOR,
-      [this.config["minor-label"]]: Version.INCREMENT_MINOR,
-      [this.config["patch-label"]]: Version.INCREMENT_PATCH,
+      [this.config["majorLabel"]]: Version.INCREMENT_MAJOR,
+      [this.config["minorLabel"]]: Version.INCREMENT_MINOR,
+      [this.config["patchLabel"]]: Version.INCREMENT_PATCH,
     };
 
     const branch = Utils.getBranch();
@@ -269,7 +269,7 @@ export default class Version {
   }
 
   getIncrementFromIssueLabels(issue) {
-    const regex = new RegExp(`^${this.config["major-label"]}|^${this.config["minor-label"]}|^${this.config["patch-label"]}`);
+    const regex = new RegExp(`^${this.config["majorLabel"]}|^${this.config["minorLabel"]}|^${this.config["patchLabel"]}`);
     // commits won't have labels property
     return issue.labels ? issue.labels
       .map((label) => label.name)

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,7 +45,7 @@ const hasRequiredFlags = cli.flags.bump || cli.flags.changelog;
 const packageOptions = Utils.getOptionsFromFile("./package.json");
 const configOptions = packageOptions.gsv || Utils.getOptionsFromFile("./gsv.json") || Utils.getOptionsFromFile("./.gsvrc");
 
-if (!configOptions || !(configOptions["majorLabel"] && configOptions["minorLabel"] && configOptions["patchLabel"])) {
+if (!configOptions || !(configOptions.majorLabel && configOptions.minorLabel && configOptions.patchLabel)) {
   console.error(`Must specify version label config options in .gsvrc, gsv.json file, or a gsv package.json entry.
     Ex:
     {

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,13 +45,13 @@ const hasRequiredFlags = cli.flags.bump || cli.flags.changelog;
 const packageOptions = Utils.getOptionsFromFile("./package.json");
 const configOptions = packageOptions.gsv || Utils.getOptionsFromFile("./gsv.json") || Utils.getOptionsFromFile("./.gsvrc");
 
-if (!configOptions || !(configOptions["major-label"] && configOptions["minor-label"] && configOptions["patch-label"])) {
+if (!configOptions || !(configOptions["majorLabel"] && configOptions["minorLabel"] && configOptions["patchLabel"])) {
   console.error(`Must specify version label config options in .gsvrc, gsv.json file, or a gsv package.json entry.
     Ex:
     {
-      "major-label": "Version: Major",
-      "minor-label": "Version: Minor",
-      "patch-label": "Version: Patch"
+      "majorLabel": "Version: Major",
+      "minorLabel": "Version: Minor",
+      "patchLabel": "Version: Patch"
     }
   `);
   process.exit(1);


### PR DESCRIPTION
In the configuration, you have both `startVersion` and `major-label`.    Should we stick with camelCase, since `package.json` uses `devDependencies`, etc.?