### PR TITLE
Use custom Github protocol and host

### DIFF
--- a/src/Version.js
+++ b/src/Version.js
@@ -18,7 +18,10 @@ export default class Version {
   static INCREMENT_PATCH = "patch";
 
   constructor(config, options) {
-    this.config = config;
+    this.config = {
+      github: {},
+      ...config,
+    };
     this.options = {
       ...Version.defaultOptions,
       ...options,
@@ -198,7 +201,9 @@ export default class Version {
     if (process.env.CI && process.env.GH_TOKEN) {
       const { user, repo } = Utils.getUserRepo();
       const token = '${GH_TOKEN}';
-      const origin = `https://${user}:${token}@github.com/${user}/${repo}.git`;
+      const protocol = this.config.github.protocol || 'https';
+      const host = this.config.github.host || 'github.com';
+      const origin = `${protocol}://${user}:${token}@${host}/${user}/${repo}.git`;
 
       debug.info(`Explicitly setting git origin to: ${origin}`);
       Utils.exec(`git remote set-url origin ${origin}`)

--- a/src/Version.js
+++ b/src/Version.js
@@ -200,9 +200,8 @@ export default class Version {
 
     if (process.env.CI && process.env.GH_TOKEN) {
       const { user, repo } = Utils.getUserRepo();
+      const { protocol = 'https', host = 'github.com' } = this.config.github;
       const token = '${GH_TOKEN}';
-      const protocol = this.config.github.protocol || 'https';
-      const host = this.config.github.host || 'github.com';
       const origin = `${protocol}://${user}:${token}@${host}/${user}/${repo}.git`;
 
       debug.info(`Explicitly setting git origin to: ${origin}`);


### PR DESCRIPTION
My recent change that allowed for the customization of the Github API instance worked, however, there was one piece that didn't, as this URL was hardcoded to `github.com`. Simple fix.

@ericclemmons 