### PR TITLE
Attempt to detect squashed commits

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -95,7 +95,10 @@ export default class Utils {
           throw new Error(`Could not parse name, email, & message from: ${commit}`);
         }
 
-        [ , pr ] = message.match(/^Merge pull request #(\d+)|\(#(\d+)\)$/) || [];
+        const match = message.match(/^Merge pull request #(\d+)|\(#(\d+)\)$/) || [];
+
+        // 2 = squash, 1 = merge
+        pr = match[2] || match[1];
 
         return !!pr;
       });


### PR DESCRIPTION
@daveashworth @ericclemmons 

While using this, we've noticed that all releases end up being patches, even when major/minor labels are assigned. Debugs stated the following:

```
github-semantic-version:info Executing: git log --merges -n1 --format='%an|%ae|+0ms' v1.5.6..HEAD
github-semantic-version:warn No merge commits found between: v1.5.6..HEAD +19ms
github-semantic-version:warn Only commits found. Defaulting to patch. +1ms
```

As it turns out, we use squash merges for 100% of PRs, thus resulting in no merge commit, which causes this function to fail: https://github.com/ericclemmons/github-semantic-version/blob/master/src/Utils.js#L68

Squashed commits follow this structure, `Some message (#123)`, which makes it easily detectable. My changes attempt to solve this scenario.